### PR TITLE
Solve 403 errors while creating tag templates 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You would need to create Google Cloud's Application Default Credentials using
 gcloud auth application-default login
 ```
 
-#### Service Account Problem
+#### Treaform Service Account Problem
 If you are using cloud shell with terraform, you will need to assign `Service Account Token Creator` role to the user account you have authenticated the cloud shell session with/ This is not the same as the default service account - which works for most of the teraform actions. 
 
 One will encounter a `403` error while creating tag templates during the setup below without `Service Account Token Creator` role assigned to the user. 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ You would need to create Google Cloud's Application Default Credentials using
 gcloud auth application-default login
 ```
 
+#### Service Account Problem
+If you are using cloud shell with terraform, you will need to assign `Service Account Token Creator` role to the user account you have authenticated the cloud shell session with/ This is not the same as the default service account - which works for most of the teraform actions. 
+
+One will encounter a `403` error while creating tag templates during the setup below without `Service Account Token Creator` role assigned to the user. 
+
+
 To start the data mesh infrastructure build process:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@ You would need to create Google Cloud's Application Default Credentials using
 gcloud auth application-default login
 ```
 
-#### Treaform Service Account Problem
-If you are using cloud shell with terraform, you will need to assign `Service Account Token Creator` role to the user account you have authenticated the cloud shell session with/ This is not the same as the default service account - which works for most of the teraform actions. 
-
-One will encounter a `403` error while creating tag templates during the setup below without `Service Account Token Creator` role assigned to the user. 
+#### Permissions of the principal running the Terraform scripts
+Typicially a person with `Owner` or `Editor` basic roles will execute the Terraform scripts to set up the infrastructure of the Data Mesh. These scripts can also be run using a service account with sufficent privileges. 
+It is important that the principal running the scripts has `Service Account Token Creator` role. Without it the scripts will fail with a `403` error while creating tag templates. 
 
 
 To start the data mesh infrastructure build process:


### PR DESCRIPTION
added description to resolve a 403 error that comes while creating tag templates (at least in argolis env)